### PR TITLE
feishu: add x64

### DIFF
--- a/bucket/feishu.json
+++ b/bucket/feishu.json
@@ -6,23 +6,39 @@
         "identifier": "EULA",
         "url": "https://feishu.cn/en/terms"
     },
-    "url": "https://sf3-cn.feishucdn.com/obj/ee-appcenter/b0208d96/Feishu-win32_ia32-7.43.7-signed.exe#/dl.7z",
-    "hash": "md5:0da580ce7d170aa6b2bca180e014b65c",
+    "architecture": {
+        "64bit": {
+            "url": "https://lf6-ug-sign.feishucdn.com/ee-appcenter/06b03c1c/Feishu-win32_x64-7.43.7-signed.exe?lk3s=fb957577&x-expires=1747882492&x-signature=YaDLhrPm%2FEv1IhBBg9tot3Pm2fs%3D#/dl.7z",
+            "hash": "md5:ba850804e14fd7c45b5c2f8f9219f803"
+        },
+        "32bit": {
+            "url": "https://sf3-cn.feishucdn.com/obj/ee-appcenter/b0208d96/Feishu-win32_ia32-7.43.7-signed.exe#/dl.7z",
+            "hash": "md5:0da580ce7d170aa6b2bca180e014b65c"
+        }
+    },
     "extract_to": "app",
     "bin": "app/Feishu.exe",
     "shortcuts": [
-        [
-            "app/Feishu.exe",
-            "Feishu"
-        ]
+        ["app/Feishu.exe", "Feishu"]
     ],
     "checkver": {
         "url": "https://feishu.cn/api/downloads",
         "jp": "$.versions.Windows.download_link",
-        "regex": "/(?<id>[\\d\\w]+)/Feishu-(?<arch>[\\d\\w]+)-([\\d\\.]+)\\-signed\\.exe"
+        "regex": "/(?<id>[\\d\\w]+)/Feishu-(?<arch>win32_ia32|win32_x64)-(?<version>[\\d\\.]+)\\-signed\\.exe",
+        "replace": {
+            "win32_ia32": "32bit",
+            "win32_x64": "64bit"
+        }
     },
     "autoupdate": {
-        "url": "https://sf3-cn.feishucdn.com/obj/ee-appcenter/$matchId/Feishu-$matchArch-$version-signed.exe#/dl.7z",
+        "architecture": {
+            "64bit": {
+                "url": "https://lf6-ug-sign.feishucdn.com/ee-appcenter/$matchId/Feishu-win32_x64-$version-signed.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://sf3-cn.feishucdn.com/obj/ee-appcenter/$matchId/Feishu-win32_ia32-$version-signed.exe#/dl.7z"
+            }
+        },
         "hash": {
             "url": "https://feishu.cn/api/downloads",
             "jp": "$.versions.Windows.hash"


### PR DESCRIPTION
本地测试可以安装，但是链接那里不知道如何处理，看着不太美观，而且貌似有有效期，等大佬出手修改吧

![image](https://github.com/user-attachments/assets/7caf231f-c417-4516-ae10-60bb8a818479)
